### PR TITLE
Include policy_krb.conf inside cupsd.conf

### DIFF
--- a/gcs/install_scripts/pos/add-krb-policy-to-cupsd.conf
+++ b/gcs/install_scripts/pos/add-krb-policy-to-cupsd.conf
@@ -1,2 +1,17 @@
-[ -f /etc/cups/cupsd.conf ] && \
-    echo "Include /etc/cups/policy_krb.conf" >> /etc/cups/cupsd.conf
+
+systemctl is-active --quiet service && systemctl stop cups
+
+EXISTAD=1
+if [ -f /etc/cups/cupsd.conf ]
+then
+	EXISTAD=`grep "Policy Kerberos-AD" /etc/cups/cupsd.conf | wc -l`
+
+fi
+
+if [ $EXISTAD -eq 0 ]
+then
+    cat /etc/cups/policy_krb.conf >> /etc/cups/cupsd.conf
+fi
+
+systemctl start cups
+

--- a/gcs/remove_scripts/pos/remove-krb-policy-to-cupsd.conf
+++ b/gcs/remove_scripts/pos/remove-krb-policy-to-cupsd.conf
@@ -1,1 +1,16 @@
-sed -i '/^Include \/etc\/cups\/policy_krb.conf/d' /etc/cups/cupsd.conf
+systemctl is-active --quiet service && systemctl stop cups
+
+EXISTAD=0
+if [ -f /etc/cups/cupsd.conf ]
+then
+	EXISTAD=`grep "Policy Kerberos-AD" /etc/cups/cupsd.conf | wc -l`
+
+fi
+
+if [ $EXISTAD -eq 1 ]
+then
+	LINES=`cat /etc/cups/policy_krb.conf | wc -l`
+	sed -i '/^<Policy Kerberos-AD>/,+'$LINES'd' /etc/cups/cupsd.conf
+fi
+
+systemctl start cups


### PR DESCRIPTION
Since the "Include" instruction has been removed from cupsd.conf for security purposses, now we must include the content of policy_krb.conf inside cupsd.conf